### PR TITLE
 ERC998PossessERC721.sol changes

### DIFF
--- a/contracts/ERC998PossessERC721.sol
+++ b/contracts/ERC998PossessERC721.sol
@@ -84,9 +84,9 @@ contract ERC998PossessERC721 is ERC998NFT, ERC998NFTEnumerable {
       uint256 lastContractIndex = childContracts[_tokenId].length - 1;
       address lastContract = childContracts[_tokenId][lastContractIndex];
       childContracts[_tokenId][contractIndex] = lastContract;
-      childContracts[_tokenId].length--;
-      delete childContractIndex[_tokenId][_childContract];
       childContractIndex[_tokenId][lastContract] = contractIndex;
+      childContracts[_tokenId].length--;
+      delete childContractIndex[_tokenId][_childContract];      
     }
   }
 

--- a/contracts/ERC998PossessERC721.sol
+++ b/contracts/ERC998PossessERC721.sol
@@ -129,14 +129,14 @@ contract ERC998PossessERC721 is ERC721Receiver {
   
   // returns the childs owned by the composable for a specific child contract
   function childsOwnedBy(uint256 _tokenId, address _childContract) public view returns (uint256[]) {
-    return childTokens[_childOwner(_tokenId, _childContract)];
+    return childTokens[_tokenId][_childContract];
   }
   
   // check if child is owned by this composable
   function childIsOwned(
     uint256 _tokenId, address _childContract, uint256 _childTokenId
   ) public view returns (bool) {
-    return childOwned[_childAddress(_tokenId, _childContract, _childTokenId)];
+    return childTokenIndex[_tokenId][_childContract][_childTokenId] != 0;    
   }
   
 }

--- a/contracts/ERC998PossessERC721.sol
+++ b/contracts/ERC998PossessERC721.sol
@@ -73,9 +73,9 @@ contract ERC998PossessERC721 is ERC998NFT, ERC998NFTEnumerable {
     uint256 lastTokenIndex = childTokens[_tokenId][_childContract].length-1;
     uint256 lastToken = childTokens[_tokenId][_childContract][lastTokenIndex];
     childTokens[_tokenId][_childContract][tokenIndex-1] = lastToken;
-    childTokens[_tokenId][_childContract].length--;
-    delete childTokenIndex[_tokenId][_childContract][_childTokenId];
     childTokenIndex[_tokenId][_childContract][lastToken] = tokenIndex;
+    childTokens[_tokenId][_childContract].length--;
+    delete childTokenIndex[_tokenId][_childContract][_childTokenId];    
     delete childTokenOwner[_childContract][_childTokenId];
 
     // remove contract

--- a/contracts/ERC998PossessERC721.sol
+++ b/contracts/ERC998PossessERC721.sol
@@ -2,10 +2,9 @@
 
 //jshint ignore: start
 
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 import "zeppelin-solidity/contracts/token/ERC721/ERC721Receiver.sol";
-import "./ERC998Helpers.sol";
 
 contract ERC998PossessERC721 is ERC721Receiver {
 
@@ -17,117 +16,106 @@ contract ERC998PossessERC721 is ERC721Receiver {
   * Child Mappings
   **************************************/
   
-  // mapping from nft to all child contracts
-  mapping(uint256 => address[]) childContracts;
+  // tokenId => child contract
+  mapping(uint256 => address[]) private childContracts;
+    
+  // tokenId => (child address => contract index+1)
+  mapping(uint256 => mapping(address => uint256)) private childContractIndex;
   
-  // mapping for the child contract address index in the childContracts array
-  mapping(uint256 => mapping(address => uint256)) childContractIndex;
+  // tokenId => (child address => array of child tokens)
+  mapping(uint256 => mapping(address => uint256[])) private childTokens;
   
-  // mapping from contract pseudo-address owner nftp to the tokenIds
-  mapping(address => uint256[]) childTokens;
-  
-  // mapping from pseudo owner address to childTokenId to array index
-  mapping(address => mapping(uint256 => uint256)) childTokenIndex;
-  
-  // mapping child pseudo-address to bool
-  mapping(address => bool) childOwned;
+  // tokenId => (child address => (child token => child index+1)
+  mapping(uint256 => mapping(address => mapping(uint256 => uint256))) private childTokenIndex;
   
   /**************************************
   * Events
   **************************************/
   
-  event Received(address _from, uint256 _childTokenId, bytes _data);
+  event Received(address indexed _from, uint256 _childTokenId, bytes _data);
   
-  event Added(uint256 _tokenId, address _childContract, uint256 _childTokenId);
+  event Added(uint256 indexed _tokenId, address _childContract, uint256 _childTokenId);
   
   event TransferChild(address _from, address _to, uint256 _childTokenId);
   
+  
   /**************************************
-  * Utility Methods
+  * Transfer and Receive Methods
   **************************************/
+  
+  function childReceived(address _from, uint256 _childTokenId, bytes _data) private {
+    // convert _data bytes to uint256, owner nft tokenId passed as uint in bytes
+    // bytesToUint(_data) i.e. tokenId = 5 would be "5" coming from web3 or another contract
+    uint256 _tokenId;
+    assembly { 
+      _tokenId := mload(add(_data, 32)) 
+    }
+    if(_data.length < 32) {
+      _tokenId = _tokenId >> 256 - _data.length * 8;
+    }
 
-  // generates a pseudo-address from the nft that owns, child contract
-  function _childOwner(
-    uint256 _tokenId, address _childContract
-  ) internal pure returns (address) {
-    return address(keccak256(_tokenId, _childContract));
+    uint256 childTokensLength = childTokens[_tokenId][_from].length;
+    if(childTokensLength == 0) {
+      childContracts[_tokenId].push(_from);
+      childContractIndex[_tokenId][_from] = childContracts[_tokenId].length;
+    }
+    childTokens[_tokenId][_from].push(_childTokenId);
+    childTokenIndex[_tokenId][_from][_childTokenId] = childTokensLength+1;
+
+    emit Added(_tokenId, _from, _childTokenId);
   }
-  
-  // generates a pseudo-address for the child from the nft that owns, child contract, child tokenId
-  function _childAddress(
-    uint256 _tokenId, address _childContract, uint256 _childTokenId
-  ) internal pure returns (address) {
-    return address(keccak256(_tokenId, _childContract, _childTokenId));
+    
+
+  // receiving NFT to composable, _data is bytes (string) tokenId
+  function onERC721Received(address _from, uint256 _childTokenId, bytes _data) external returns(bytes4) {
+    childReceived(msg.sender, _childTokenId, _data);
+    return ERC721_RECEIVED;
   }
-  
-  // removes child contract from list of possession contracts
-  function _removeContract(uint256 _tokenId, address _childContract) internal {
-    uint256 contractIndex = childContractIndex[_tokenId][_childContract];
-    uint256 lastContractIndex = childContracts[_tokenId].length - 1;
-    address lastContract = childContracts[_tokenId][lastContractIndex];
-    childContracts[_tokenId][contractIndex] = lastContract;
-    childContracts[_tokenId][lastContractIndex] = 0;
-    childContracts[_tokenId].length--;
-    childContractIndex[_tokenId][_childContract] = 0;
-    childContractIndex[_tokenId][lastContract] = contractIndex;
+
+  function transferChild_(address _to, uint256 _tokenId, address _childContract, uint256 _childTokenId) internal {
+    uint256 tokenIndex = childTokenIndex[_tokenId][_childContract][_childTokenId];
+    require(tokenIndex != 0, "Child token not owned by tokenId.");
+
+    // remove child token
+    uint256 lastTokenIndex = childTokens[_tokenId][_childContract].length-1;
+    uint256 lastToken = childTokens[_tokenId][_childContract][lastTokenIndex];
+    childTokens[_tokenId][_childContract][tokenIndex-1] = lastToken;
+    childTokens[_tokenId][_childContract].length--;
+    delete childTokenIndex[_tokenId][_childContract][_childTokenId];
+    childTokenIndex[_tokenId][_childContract][lastToken] = tokenIndex;
+
+    // remove contract
+    if(lastTokenIndex == 0) {
+        uint256 contractIndex = childContractIndex[_tokenId][_childContract];
+        uint256 lastContractIndex = childContracts[_tokenId].length - 1;
+        address lastContract = childContracts[_tokenId][lastContractIndex];
+        childContracts[_tokenId][contractIndex-1] = lastContract;
+        childContracts[_tokenId].length--;
+        delete childContractIndex[_tokenId][_childContract];
+        childContractIndex[_tokenId][lastContract] = contractIndex;
+    }
+
+    emit TransferChild(this, _to, _childTokenId);
   }
-  
-  // removes child from list of possessions
-  function _removeChild(address childOwner, uint256 _childTokenId) internal {
-    uint256 tokenIndex = childTokenIndex[childOwner][_childTokenId];
-    uint256 lastTokenIndex = childTokens[childOwner].length - 1;
-    uint256 lastToken = childTokens[childOwner][lastTokenIndex];
-    childTokens[childOwner][tokenIndex] = lastToken;
-    childTokens[childOwner][lastTokenIndex] = 0;
-    childTokens[childOwner].length--;
-    childTokenIndex[childOwner][_childTokenId] = 0;
-    childTokenIndex[childOwner][lastToken] = tokenIndex;
-  }
-  
-  /**************************************
-  * Internal Transfer and Receive Methods
-  **************************************/
-  
-  function transferChild(
-    address _to, uint256 _tokenId, address _childContract, uint256 _childTokenId
-  ) internal {
-    // get the pseudo address of the child from the composable owner, child contract and child tokenId
-    address child = _childAddress(_tokenId, _childContract, _childTokenId);
-    //require that the child is owned
-    require(childOwned[child] == true);
+
+  function transferChild(address _to, uint256 _tokenId, address _childContract, uint256 _childTokenId) external {
+    transferChild_(_to, _tokenId, _childContract, _childTokenId);
     //require that the child was transfered safely to it's destination
     require(
       _childContract.call(
-        bytes4(keccak256("safeTransferFrom(address,address,uint256)")),
-        this, _to, _childTokenId
+        bytes4(keccak256("safeTransferFrom(address,address,uint256)")), this, _to, _childTokenId
       )
     );
-    // remove the parent token's ownership of the child token
-    childOwned[child] = false;
-    // remove the child contract and index
-    _removeContract(_tokenId, _childContract);
-    // _childOwner is _tokenId and _childContract pseudo address
-    address childOwner = _childOwner(_tokenId, _childContract);
-    _removeChild(childOwner, _childTokenId);
-    
-    emit TransferChild(this, _to, _childTokenId);
   }
-  
-  function childReceived(address _from, uint256 _childTokenId, bytes _data) internal {
-    // convert _data bytes to uint256, owner nft tokenId passed as string in bytes
-    // bytesToUint(_data) i.e. tokenId = 5 would be "5" coming from web3 or another contract
-    uint256 _tokenId = ERC998Helpers.bytesToUint(_data);
-    // log the child contract and index
-    childContractIndex[_tokenId][_from] = childContracts[_tokenId].length;
-    childContracts[_tokenId].push(_from);
-    // log the tokenId and index
-    address childOwner = _childOwner(_tokenId, _from);
-    childTokenIndex[childOwner][_childTokenId] = childTokens[childOwner].length;
-    childTokens[childOwner].push(_childTokenId);
-    // set bool of owned to true
-    childOwned[_childAddress(_tokenId, _from, _childTokenId)] = true;
-    // emit event
-    emit Added(_tokenId, _from, _childTokenId);
+
+  function transferChild(address _to, uint256 _tokenId, address _childContract, uint256 _childTokenId, bytes data) external {
+    transferChild_(_to, _tokenId, _childContract, _childTokenId);
+    //require that the child was transfered safely to it's destination
+    require(
+      _childContract.call(
+        bytes4(keccak256("safeTransferFrom(address,address,uint256,bytes)")), this, _to, _childTokenId, data
+      )
+    );
   }
   
   /**************************************
@@ -149,31 +137,6 @@ contract ERC998PossessERC721 is ERC721Receiver {
     uint256 _tokenId, address _childContract, uint256 _childTokenId
   ) public view returns (bool) {
     return childOwned[_childAddress(_tokenId, _childContract, _childTokenId)];
-  }
-  
-  /**************************************
-  * Public Transfer and Receive Functions
-  **************************************/
-  
-  // sending child to account
-  // function safeTransferChild(
-  //   address _to, uint256 _tokenId, address _childContract, uint256 _childTokenId
-  // ) public {
-  //   transferChild(_to, _tokenId, _childContract, _childTokenId);
-  // }
-  
-  // sending child directly to another composable
-  function safeTransferChild(
-    address _to, uint256 _tokenId, address _childContract, uint256 _childTokenId, bytes _data
-  ) public {
-    transferChild(_to, _tokenId, _childContract, _childTokenId);
-    childReceived(_childContract, _childTokenId, _data);
-  }
-  
-  // receiving NFT to composable, _data is bytes (string) tokenId
-  function onERC721Received(address _from, uint256 _childTokenId, bytes _data) public returns(bytes4) {
-    childReceived(msg.sender, _childTokenId, _data);
-    return ERC721_RECEIVED;
   }
   
 }


### PR DESCRIPTION
This is actually the first time I have done a pull request so excuse me if I do something wrong. And let me know how to do it better next time.

I made some interesting changes to  ERC998PossessERC721.sol.   Let me describe why I made the changes.

1. I replaced the pseudo-addresses with nested maps because the pseudo-addresses don't help with gas.
2. I got rid of mapping(address => bool) childOwned. I did this by indexing childTokenIndex starting with 1 instead of 0 so that a 0 value means that the child does not exist. This change reduces the gas in the onERC721Received function by about 20,000 gas because a separate owned value does not need to be stored.
3. I replaced the childReceived function with onERC721Received.
4. The onERC721Received function expects the _data argument to contain an actual integer value instead of an ascii string that represents a number. Up to 32 bytes of the _data argument is converted to an uint256. I made this change for these reasons: 
    1. The bit of assembly that converts bytes to an uint256 uses much less gas than converting a string number into a uint256. 
    2.  Up to the first 32 bytes of _data are converted to uint256. This allows bytes after the first 32 to be contract specific and customizable by contracts for their purposes.
4. The onERC721Received function only adds a new contract when it doesn't already exist and the removeChild function only removes a contract when the number of tokens for it becomes 0.
5. The code that calls `safeTransferFrom` is moved after bookkeeping to prevent re-entry attacks. If this was executed before bookkeeping then it would be possible to mess up the bookeeping by re-entrying the contract when `safeTransferFrom` is called.
6. The `transferChild(address _to, uint256 _tokenId, address _childContract, uint256 _childTokenId, bytes data)` function can be used to transfer child tokens to user accounts and to transfer tokens to consumable tokens.
7. I created the interfaces ERC998NFT and ERC998NFTEnumerable and implemented them.
8. I added the childOwnerOf functions. This is like the ownerOf function from ERC721 except it gives the token owner of a child token.
9. I added the childTokenOwner mapping which is used by the childOwnerOf function.

I would love some feedback on all these changes and additions. 

