### PR TITLE
Transfer Changes

### DIFF
--- a/test/composable.js
+++ b/test/composable.js
@@ -211,13 +211,20 @@ contract('Composable', function(accounts) {
   });
   
   /**************************************
-  * Checking transferChildToComposable from Composable
+  * Checking safeTransferChild from Composable to Composable
   **************************************/
-  it('should transferChildToComposable to from composable 2 to composable 1', async () => {
-    const tx = await composable.transferChildToComposable(composable.address, sampleNFT.address, 2, bytes1);
-    assert(tx, 'tx undefined using transferChildToComposable');
-  });
-  
+  it('should safeTransferChild from composable 2 to composable 1', async () => {
+    //address _to, address _childContract, uint256 _childTokenId, bytes _data
+    const safeTransferChild = Composable.abi.filter(f => f.name === 'safeTransferChild' && f.inputs.length === 4)[0];
+    const transferMethodTransactionData = web3Abi.encodeFunctionCall(
+      safeTransferChild, [composable.address, sampleNFT.address, 2, bytes1]
+    );
+    const tx = await web3.eth.sendTransaction({
+      from: alice, to: composable.address, data: transferMethodTransactionData, value: 0, gas: 500000
+    });
+    assert(tx, 'tx undefined using safeTransferChild');
+    });
+
    it('should have sampleNFT contract', async () => {
     const contracts = await composable.childContractsByToken.call(1);
     


### PR DESCRIPTION
Changes:
1. I added `function safeTransferChild(address _to, address _childContract, uint256 _childTokenId)` so that child tokens can be safely transferred to contracts.
2. I replaced `transferChildToComposable` with `function safeTransferChild(address _to, address _childContract, uint256 _childTokenId, bytes _data)`.
3. I replaced the transferChildToComposable test with one that successfully uses `safeTransferChild` to transfer an NFT from a composable to a composable.
4. I made `receiveChild` private and removed it from the interface.
4. I added additional requires that ensure that tokenId exists and that a received childTokenId is owned by the receiving contract before adding it, and that the childTokeId has not already been added before adding it.
5. I added a `getChild` function and added it to the interface. `getChild` solves the problem of transferring an ERC721 token that does not have a  safeTransferChild function to a composable. For example, cryptokitties does not have a safeTransferChild function.  Here is the sequence:
   1. Using the `approve` function an ERC721 contract approves a composable contract for a token.
   2. The `getChild` function gets called on that ERC721 contract and token, which transfers the token into the composable successfully.

