### PR TITLE
Add basic package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ node_modules/
 build/
 .idea/
 composables-988.iml
-package.json
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "composables-998",
+  "version": "1.0.0",
+  "description": "ERC-998 implementation for Non-Fungible token possessions",
+  "repository": "git@github.com:mattlockyer/composables-998.git",
+  "author": "Matt Lockyer <@mattdlockyer>",
+  "devDependencies": {
+    "truffle": "^4.1.11",
+    "web3-eth-abi": "^1.0.0-beta.34",
+    "zeppelin-solidity": "^1.10.0"
+  },
+  "scripts": {
+    "test": "truffle test"
+  }
+}


### PR DESCRIPTION
First off, thanks Matt for getting this show on the road! I thought I'd dip my toes in with a simple change to start with so decided to fix #1. (apologies for the erroneous PR earlier)

Problem: For the ideal dev on boarding experience, you should be able to `git clone; cd <folder>`, run `npm install` and `npm test` in sequence to have the tests running and passing. Currently, the lack of a `package.json` file prevents that from happening; for the uninitiated, this means encountering errors with each of the 3 possible missing packages, `truffle`, `web3-eth-abi` and `zeppelin-solidity`. In addition, there is a chance that people may use mismatched versions of truffle from global installations, leading to potentially inconsistencies while running tests between multiple users.

Solution: Adds a `package.json` that includes the required packages as development dependencies. Remove `package.json` from `.gitignore`