### PR TITLE
Implemented nested authentication for transferring child NFTs

### DIFF
--- a/test/composable.js
+++ b/test/composable.js
@@ -267,6 +267,7 @@ contract('Composable', function(accounts) {
   
   it('token 1 should own SampleNFT child token 2', async () => {
     const tokenId = await composable.ownerOfChild.call(SampleNFT.address, 2);
+    //console.log(tokenId);
     assert(tokenId.equals(1), 'SampleNFT child token 2 is not owned by a composable token.');
   });
 


### PR DESCRIPTION
Added isApprovedOrOwnerOf which looks up the NFT ownership tree to see if tx.origin is owner or approved for the current NFT or any NFT up the tree. 

This should work but I did not write any tests for it. Existing tests pass.