### PR TITLE
Basic tests for ERC998NFTEnumerable / ERC998FTEnumerable

### DIFF
--- a/test/composable.js
+++ b/test/composable.js
@@ -36,13 +36,14 @@ const promisify = (inner) => new Promise((resolve, reject) =>
 const getBalance = (account, at) => promisify(cb => web3.eth.getBalance(account, at, cb));
 const timeout = ms => new Promise(res => setTimeout(res, ms))
 const setupTestTokens = async (numberOfNfts, numberOfERC20s) => {
-  nfts = [];
-  erc20s = [];
+  let nfts = [];
+  let erc20s = [];
+  let s = String(i);
   for (var i = 0; i < numberOfNfts; i++) {
-    nfts.push((await SampleNFT.new(String(i), String(i))));
+    nfts.push((await SampleNFT.new(s, s)));
   }
   for (var i = 0; i < numberOfERC20s; i++) {
-    erc20s.push((await SampleERC20.new(String(i), String(i))));
+    erc20s.push((await SampleERC20.new(s, s));
   }
   return [nfts, erc20s];
 }

--- a/test/composable.js
+++ b/test/composable.js
@@ -227,15 +227,15 @@ contract('Composable', function(accounts) {
     //address _to, address _childContract, uint256 _childTokenId, bytes _data
     const safeTransferChild = Composable.abi.filter(f => f.name === 'safeTransferChild' && f.inputs.length === 4)[0];
     const transferMethodTransactionData = web3Abi.encodeFunctionCall(
-      safeTransferChild, [composable.address, sampleNFT.address, 2, bytes1]
+      safeTransferChild, [composable.address, sampleNFT.address, 2, bytes1] 
     );
     const tx = await web3.eth.sendTransaction({
       from: alice, to: composable.address, data: transferMethodTransactionData, value: 0, gas: 500000
     });
     assert(tx, 'tx undefined using safeTransferChild');
-    });
+  });
 
-   it('should have sampleNFT contract', async () => {
+  it('should have sampleNFT contract', async () => {
     const contract = await composable.childContractByIndex.call(1,0);
     
     console.log(contract, composable.address, sampleNFT.address);


### PR DESCRIPTION
Heyo

**Problem:** Need test for ERC998NFTEnumerable / ERC998FTEnumerable

**Solution:** Add some coverage for these interfaces.

Basic idea is to setup a set of SampleNFTs/SampleERC20s, add them to a composable and then use  enumeration to find / remove them.

**New Tests**
```
✓ should return the correct number of totalTokenContracts and balances after ERC20 contracts are added (2179ms)
✓ should return the correct number of totalChildTokens and totalChildTokens after NFT contracts are added (6732ms)
✓ should return the correct number of totalTokenContracts after ERC20 contracts are removed (39ms)
✓ should return the correct number of totalChildTokens and totalChildContracts when NFT contracts are removed (6381ms)

 42 passing (19s)
```